### PR TITLE
Fix button placement

### DIFF
--- a/examples/demo.html
+++ b/examples/demo.html
@@ -241,9 +241,9 @@
       if (timeout) clearTimeout(timeout);
 
       btn.attr('data-bs-content', '<span class="text-' + type + '">' + message + '</span>');
-      btn[0].popover.show();
+      btn[0].customPopover.show();
       timeouts[id] = setTimeout(function() {
-        btn[0].popover.hide();
+        btn[0].customPopover.hide();
         delete timeouts[id];
       }, 3000);
     }
@@ -314,7 +314,7 @@
     });
 
     $('#encode,#decode').each(function () {
-      this.popover = new bootstrap.Popover(this, {
+      this.customPopover = new bootstrap.Popover(this, {
         trigger: 'manual',
         html: true
       });


### PR DESCRIPTION
Recently, the Encode/Decode buttons were misplaced in my Chrome browser on the example website:
<img width="1073" alt="Screenshot 2023-09-23 at 21 48 12" src="https://github.com/slowli/bech32-buffer/assets/83083413/e4636a3c-131d-4a5c-a269-dca933e12070">

After investigation, I found out that this happens because of the `popover` attribute which is present in Chrome browser:
<img width="374" alt="Screenshot 2023-09-23 at 23 16 51" src="https://github.com/slowli/bech32-buffer/assets/83083413/1dddcd50-719a-46a5-80e4-220284c14dbd">
and causes errors:
<img width="451" alt="Screenshot 2023-09-23 at 23 17 16" src="https://github.com/slowli/bech32-buffer/assets/83083413/389f9b42-de04-43de-99dc-c5c3ddbc8d4a">
while it's not present in FireFox:
<img width="460" alt="image" src="https://github.com/slowli/bech32-buffer/assets/83083413/bdd77c03-4305-4aa6-afc2-b04a8e9e3cc7">

It looks like it's because of the popover API recently introduced in Chrome: https://developer.chrome.com/blog/introducing-popover-api/
Because of that, the `popover` property of the button element is treated as an attribute that Chrome can't interpret properly.

The fix is way simple and implies just renaming that property from `popover` to `customPopover`